### PR TITLE
navbar legibility fixes

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -32,7 +32,7 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  opacity: .85;
+  background-color: rgba(255, 255, 255, .85);
 }
 .navbar-collapse {
   -webkit-border-radius: 0;
@@ -72,15 +72,11 @@ body {
   color: #454545;
 }
 .navbar-default .navbar-nav > li > a:hover,
-.navbar-default .navbar-nav > li > a:focus {
-  color: #000000;
-  background-color: #ffffff;
-}
+.navbar-default .navbar-nav > li > a:focus,
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:hover,
 .navbar-default .navbar-nav > .active > a:focus {
   color: #000000;
-  background-color: #ffffff;
 }
 .navbar-default .dropdown ul.dropdown-menu > li > a {
   color: #454545;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -69,7 +69,7 @@ body {
   border-color: #cccccc;
 }
 .navbar-default .navbar-nav > li > a {
-  color: #454545;
+  color: #333333;
 }
 .navbar-default .navbar-nav > li > a:hover,
 .navbar-default .navbar-nav > li > a:focus,
@@ -79,7 +79,7 @@ body {
   color: #000000;
 }
 .navbar-default .dropdown ul.dropdown-menu > li > a {
-  color: #454545;
+  color: #333333;
 }
 .navbar-default .dropdown ul.dropdown-menu > li > a:hover {
   background-color: #eeeeee;


### PR DESCRIPTION
apologies for my mistakes with my last PR -- this will make the navbar more legible in multiple ways.

before:
![image](https://user-images.githubusercontent.com/17580512/35293590-d098ba86-0039-11e8-8a6c-f4ba7d28fcf8.png)


note that the "opacity" property affects all child elements as well. i resolve this by using rgba on the background instead. also, i darken the text just a tiny bit.

after:
![image](https://user-images.githubusercontent.com/17580512/35293579-c8978614-0039-11e8-9a5f-b63ec17cc340.png)


the difference may seem subtle but affects legibility (and thus accessibility) greatly. 