### PR TITLE
Fixes missing mailto link in header

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,7 +36,7 @@
 			<img class="img-circle" src="{{ .Site.BaseURL }}images/guy.jpg" alt="">
 			<span class="title">{{ .Site.Params.name }}</span>
 			<span class="tagline">{{ .Site.Params.description }}<br>
-				<a href="">{{ .Site.Params.email }}</a>
+				<a href="mailto:{{ .Site.Params.email }}">{{ .Site.Params.email }}</a>
             </span>
 		</h1>
 	</div>


### PR DESCRIPTION
href was empty so the link refers to the current URL.

This change adds a `mailto:` link.