### PR TITLE
Add missing banner parameter

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,6 +13,7 @@ publishDir = "docs"
     year = 2017
     avatar = "images/guy.jpg"
     background = ""
+    banner = "images/bg_head.jpg"
     favicon = "images/gt_favicon.png"
     DateForm = "January 2, 2006"
 


### PR DESCRIPTION
Hi Miguel,
A little fix, to add the missing banner parameter in your example site config file.



