### PR TITLE
Fix tag nesting

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,8 +36,8 @@
                        {{ partial "home/single.html" . }}
 
                      {{ end }}
-                {{ end }}
-              </div>	<!-- /section -->
+                </div>	<!-- /section -->
+              {{ end }}
             {{ end }}
         {{ end }}
     </div>	<!-- /container -->


### PR DESCRIPTION
The closing div should be before if statement end, not after it.

In some cases, it leads to improper page rendering.